### PR TITLE
Jump to floating from left/right side, direct jump to up/down corners

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -223,6 +223,8 @@ function moveWindow(direction) {
 				placeWindow("topleft", app);
 			} else if (pos == "bottomright") {
 				placeWindow("bottomleft", app);
+			} else if (pos == "right") {
+				placeWindow("floating", app);
 			} else {
 				placeWindow("left", app);
 			}
@@ -241,6 +243,8 @@ function moveWindow(direction) {
 				placeWindow("topright", app);
 			} else if (pos == "bottomleft") {
 				placeWindow("bottomright", app);
+			} else if (pos == "left") {
+				placeWindow("floating", app);
 			} else {
 				placeWindow("right", app);
 			}
@@ -249,11 +253,11 @@ function moveWindow(direction) {
 			if (pos == "left")
 				placeWindow("topleft", app);
 			else if (pos == "bottomleft")
-				placeWindow("left", app);
+				placeWindow("topleft", app);
 			else if (pos == "right")
 				placeWindow("topright", app);
 			else if (pos == "bottomright")
-				placeWindow("right", app);
+				placeWindow("topright", app);
 			else
 				placeWindow("maximize", app);
 			break;
@@ -261,11 +265,11 @@ function moveWindow(direction) {
 			if (pos == "left")
 				placeWindow("bottomleft", app);
 			else if (pos == "topleft")
-				placeWindow("left", app);
+				placeWindow("bottomleft", app);
 			else if (pos == "right")
 				placeWindow("bottomright", app);
 			else if (pos == "topright")
-				placeWindow("right", app);
+				placeWindow("bottomright", app);
 			else if (pos == "maximized")
 				placeWindow("floating", app);
 			break;


### PR DESCRIPTION
Further mimic Windows's behavior:
* When the window is snapped to the left, moving it to the right should return the window to the floating position (as opposed to the right side)
* The same applies to the right side
* When a window is snapped to the bottom or top corner, moving to the opposite corner should skip the full left/right position